### PR TITLE
Use API endpoints for media image handling

### DIFF
--- a/app/admin/media/components/RichTextEditor.tsx
+++ b/app/admin/media/components/RichTextEditor.tsx
@@ -6,7 +6,6 @@ import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Youtube from '@tiptap/extension-youtube';
 import { useCallback, useEffect, useState } from 'react';
-import { uploadMediaImage } from '@/lib/media-storage';
 import Button from '@/shared/components/ui/Button';
 import Input from '@/shared/components/ui/Input';
 import {
@@ -97,8 +96,23 @@ export function RichTextEditor({
       if (input.files && input.files.length > 0) {
         try {
           const file = input.files[0];
-          const imageUrl = await uploadMediaImage(file);
-          editor.chain().focus().setImage({ src: imageUrl }).run();
+          
+          // Upload via API
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const response = await fetch('/api/media/upload-image', {
+            method: 'POST',
+            body: formData,
+          });
+
+          if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.error || 'Upload failed');
+          }
+
+          const result = await response.json();
+          editor.chain().focus().setImage({ src: result.data.url }).run();
         } catch (error) {
           console.error('Failed to upload image:', error);
           alert('Failed to upload image. Please try again.');

--- a/app/api/media/delete-image/route.ts
+++ b/app/api/media/delete-image/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { deleteMediaImage } from '@/lib/media-storage';
+import { isAuthenticated, isAuthorised } from '@/lib/db/auth';
+
+export async function DELETE(request: NextRequest) {
+  try {
+    // Check authentication
+    const authenticated = await isAuthenticated();
+    if (!authenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Check authorization
+    const requiredRoles = ['admin', 'editor'];
+    const authorised = await isAuthorised(requiredRoles);
+    if (!authorised) {
+      return NextResponse.json(
+        { error: 'Insufficient permissions' },
+        { status: 403 }
+      );
+    }
+
+    const { url } = await request.json();
+
+    if (!url) {
+      return NextResponse.json({ error: 'No URL provided' }, { status: 400 });
+    }
+
+    await deleteMediaImage(url);
+
+    return NextResponse.json({
+      success: true,
+    });
+  } catch (error) {
+    console.error('Delete image error:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete image' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/media/upload-image/route.ts
+++ b/app/api/media/upload-image/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { uploadMediaImage } from '@/lib/media-storage';
+import { isAuthenticated, isAuthorised } from '@/lib/db/auth';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Check authentication
+    const authenticated = await isAuthenticated();
+    if (!authenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Check authorization
+    const requiredRoles = ['admin', 'editor'];
+    const authorised = await isAuthorised(requiredRoles);
+    if (!authorised) {
+      return NextResponse.json(
+        { error: 'Insufficient permissions' },
+        { status: 403 }
+      );
+    }
+
+    const formData = await request.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    // Validate file type (images only)
+    if (!file.type.startsWith('image/')) {
+      return NextResponse.json(
+        { error: 'Only image files are allowed' },
+        { status: 400 }
+      );
+    }
+
+    // Validate file size (max 10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: 'File size must be less than 10MB' },
+        { status: 400 }
+      );
+    }
+
+    const imageUrl = await uploadMediaImage(file);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        url: imageUrl,
+      },
+    });
+  } catch (error) {
+    console.error('Upload image error:', error);
+    return NextResponse.json(
+      { error: 'Failed to upload image' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/media-storage.ts
+++ b/lib/media-storage.ts
@@ -1,9 +1,9 @@
-import { supabase } from '@/lib/supabase/client';
 import { v4 as uuidv4 } from 'uuid';
 import { createServer } from './supabase/server';
 
 // Media image handling
 export const uploadMediaImage = async (file: File): Promise<string> => {
+  const supabase = await createServer();
   const uniqueId = uuidv4();
   const filePath = `${uniqueId}_${file.name.replace(/[^a-zA-Z0-9.-]/g, '_')}`;
 


### PR DESCRIPTION
Centralize media image uploads and deletions behind Next.js API routes to remove direct storage logic from the client. Update MediaForm and RichTextEditor to POST and DELETE images via `/api/media/upload-image` and `/api/media/delete-image`. Simplify client code and secure storage interactions by moving Supabase calls server-side.